### PR TITLE
AWSUK-4845 - disable public bucket access on S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ module "s3_bucket" {
 | acl | (Optional) The canned ACL to apply. Defaults to 'private'. | string | `"private"` | no |
 | attach\_elb\_log\_delivery\_policy | Controls if S3 bucket should have ELB log delivery policy attached | bool | `"false"` | no |
 | attach\_policy | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | bool | `"false"` | no |
+| block\_public\_access | (Optional, Default: true) Enables block_public_acls, block_public_policy, ignore_public_acls and restrict_public_buckets (Warning: setting to false will [fail Security Hub controls](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-1) | bool | `"true"` | no
 | bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | string | `"null"` | no |
 | bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | string | `"null"` | no |
 | cors\_rule | Map containing a rule of Cross-Origin Resource Sharing. | any | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -217,6 +217,16 @@ resource "aws_s3_bucket" "this" {
 
 }
 
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+  count = var.create_bucket ? 1 : 0
+
+  bucket              = aws_s3_bucket.this[0].id
+  block_public_acls   = var.block_public_access
+  block_public_policy = var.block_public_access
+  ignore_public_acls  = var.block_public_access
+  restrict_public_buckets = var.block_public_access
+}
+
 resource "aws_s3_bucket_policy" "this" {
   count = var.create_bucket && (var.attach_elb_log_delivery_policy || var.attach_policy) ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "policy" {
   default     = null
 }
 
+variable "block_public_access" {
+  description = "(Optional, Default: true) Enables block_public_acls, block_public_policy, ignore_public_acls and restrict_public_buckets (Warning: setting to false will trigger Security Hub)"
+  type        = bool
+  default     = true
+}
+
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the bucket."
   type        = map(string)


### PR DESCRIPTION
## Description
This change adds configuration of the 4 public access settings of an S3 bucket, which together combine to define "All public access" setting. The default is to block all public access, but is configurable to set to false.

https://tickets.intelliflo.com/browse/AWSUK-4845


## Motivation and Context
Allowing public access to S3 buckets is considered medium to critical risk according to standards being adopted - https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-1. In order to address to risk and better protect objects in S3, the default S3 configuration should be to restrict public access as per remediation guidelines above.

## Breaking Changes
These changes may be breaking, need to still confirm the extent of impact that making these changes will have. Submitting PR for review of implementation, and guidance on evaluating how to apply to all buckets safely / without breaking anything that depends on public access.

## How Has This Been Tested?
Created a bucket without the changes in a test environment, added the changes in and applied to ensure the ACLs were set to true (i.e. block public access).
